### PR TITLE
Detached Tabs Workaround

### DIFF
--- a/src/provider/tabbing/TabUtilities.ts
+++ b/src/provider/tabbing/TabUtilities.ts
@@ -130,7 +130,7 @@ export async function createTabGroupsFromTabBlob(tabBlob: TabBlob[]): Promise<vo
         await group.switchTab({uuid: blob.groupInfo.active.uuid, name: blob.groupInfo.active.name});
     }
 
-    TabService.INSTANCE.tabGroups.forEach(group => group.realignApps());
+   
 }
 
 (window as Window & {createTabGroupsFromTabBlob: Function}).createTabGroupsFromTabBlob = createTabGroupsFromTabBlob;

--- a/src/provider/tabbing/TabUtilities.ts
+++ b/src/provider/tabbing/TabUtilities.ts
@@ -129,8 +129,6 @@ export async function createTabGroupsFromTabBlob(tabBlob: TabBlob[]): Promise<vo
         await group.realignApps();
         await group.switchTab({uuid: blob.groupInfo.active.uuid, name: blob.groupInfo.active.name});
     }
-
-   
 }
 
 (window as Window & {createTabGroupsFromTabBlob: Function}).createTabGroupsFromTabBlob = createTabGroupsFromTabBlob;

--- a/src/provider/workspaces/restore.ts
+++ b/src/provider/workspaces/restore.ts
@@ -257,5 +257,6 @@ export const restoreLayout = async(payload: Layout, identity: Identity): Promise
     // Regroup the windows
     await regroupLayout(allAppResponses).catch(console.log);
     // send the layout back to the requester of the restore
+    TabService.INSTANCE.tabGroups.forEach(group => group.realignApps());
     return layout;
 };


### PR DESCRIPTION
There is a suspicion something is touching groups.  We move the regroup logic to the end to ensure tabsets will have the correct window grouping.